### PR TITLE
Correct detect variable types

### DIFF
--- a/tests/testcases/can-identify-array.test.sh
+++ b/tests/testcases/can-identify-array.test.sh
@@ -8,3 +8,6 @@ tests:ensure types:is-array array_var_1
 
 typeset -a array_var_2
 tests:ensure types:is-array array_var_2
+
+typeset -xlura array_var_3
+tests:ensure types:is-array array_var_3

--- a/tests/testcases/can-identify-assoc-array.test.sh
+++ b/tests/testcases/can-identify-assoc-array.test.sh
@@ -5,3 +5,6 @@ tests:not tests:ensure types:is-assoc-array int_var
 
 typeset -A array_var_2
 tests:ensure types:is-assoc-array array_var_2
+
+typeset -xrluA array_var_3
+tests:ensure types:is-assoc-array array_var_3

--- a/types.bash
+++ b/types.bash
@@ -4,7 +4,7 @@ function types:is-assoc-array() {
         return 1
     fi >&2
 
-    declare -pA | grep -qP "^declare -A $1="
+    declare -pA | grep -q "^declare -A[^ ]* $1="
 }
 
 function types:is-array() {
@@ -13,5 +13,5 @@ function types:is-array() {
         return 1
     fi >&2
 
-    declare -pa | grep -qP "^declare -a $1="
+    declare -pa | grep -q "^declare -a[^ ]* $1="
 }


### PR DESCRIPTION
- Allow detect assoc array/array with additional attributes
- Remove useless grep `-P`
